### PR TITLE
#64; updates resources with replicate.json.

### DIFF
--- a/execute/step/constructStepJson.js
+++ b/execute/step/constructStepJson.js
@@ -101,7 +101,6 @@ function _prepareStepJSON(bag, next) {
       var integrationObject;
       if (runResourceVersion) {
         var resource = runResourceVersion;
-        resource.resourceId = runStepConnection.operationRunResourceVersionId;
         resource.operation = runStepConnection.operation;
         resource.isTrigger = runStepConnection.isTrigger;
 

--- a/execute/step/handlers/handleDependency.js
+++ b/execute/step/handlers/handleDependency.js
@@ -47,7 +47,7 @@ function _handleDependency(bag, dependency, next) {
     dependency.name);
   bag.stepConsoleAdapter.openCmd(msg);
   bag.stepConsoleAdapter.publishMsg('Version Id: ' +
-    dependency.version.id);
+    (dependency.version && dependency.version.id));
 
   var pathPlaceholder = '{{TYPE}}';
   var osType = global.config.shippableNodeOperatingSystem;

--- a/execute/step/prepData.js
+++ b/execute/step/prepData.js
@@ -200,6 +200,7 @@ function _getResources(bag, next) {
             var resource =
               indexResourcesByName[runResourceVersion.resourceName];
             if (!_.isEmpty(resource)) {
+              runResourceVersion.resourceId = resource.id;
               runResourceVersion.systemPropertyBag = resource.systemPropertyBag;
             }
           }


### PR DESCRIPTION
#64 

Parses the `replicate.json` and creates a new version of the resource if it doesn't match the previous version.  Updated to initialize the new version to an object that can be extended and better compared and corrected the `resourceId` to be a resource.  I have not, however, tested with the `.env` files.