### PR TITLE
add envs from step.json to the step

### DIFF
--- a/execute/executeStep.js
+++ b/execute/executeStep.js
@@ -342,7 +342,8 @@ function _constructStepJson(bag, next) {
         bag.error = true;
         bag.isSetupGrpSuccess = false;
       } else {
-        bag = _.extend(bag, resultBag);
+        bag.stepData = resultBag.stepData;
+        bag.stepEnvs = resultBag.stepEnvs;
       }
 
       return next();
@@ -405,6 +406,7 @@ function _createStepletScript(bag, next) {
 
   var innerBag = {
     stepData: bag.stepData,
+    stepEnvs: bag.stepEnvs,
     execTemplatesRootDir: bag.execTemplatesRootDir,
     stepletScriptPath: bag.stepletScriptPaths[0],
     builderApiToken: bag.builderApiToken,

--- a/execute/step/createStepletScript.js
+++ b/execute/step/createStepletScript.js
@@ -11,6 +11,7 @@ var assemble = require('../../assembler/assemble.js');
 function createStepletScript(externalBag, callback) {
   var bag = {
     stepData: externalBag.stepData,
+    stepEnvs: externalBag.stepEnvs,
     execTemplatesRootDir: externalBag.execTemplatesRootDir,
     stepletScriptPath: externalBag.stepletScriptPath,
     runStatusDir: externalBag.runStatusDir,
@@ -49,6 +50,7 @@ function _checkInputParams(bag, next) {
 
   var expectedParams = [
     'stepData',
+    'stepEnvs',
     'execTemplatesRootDir',
     'stepletScriptPath',
     'stepletId',
@@ -81,7 +83,7 @@ function _setScriptEnvs(bag, next) {
   var who = bag.who + '|' + _setScriptEnvs.name;
   logger.verbose(who, 'Inside');
 
-  var scriptEnvs = [];
+  var scriptEnvs = bag.stepEnvs || [];
 
   _.each({
       'PIPLELINES_RUN_STATUS_DIR': bag.runStatusDir,


### PR DESCRIPTION
closes #59

prints a warning if one of the keys was not of an appropriate type to be exported. wondering if the internal write_output function should also print a warning if the key will not export correctly later...

![image](https://user-images.githubusercontent.com/6869398/56338768-442c0100-6160-11e9-8fe5-0f6c78a7584b.png)

from a printenv:
![image](https://user-images.githubusercontent.com/6869398/56338795-645bc000-6160-11e9-9997-d0712a1b8260.png)

tested with a kubeConfig yml file and a password with a bunch of special chars, including $, space, single quote, parenthesis. seems to work as intended.