### PR TITLE
#90; uploads step artifacts.

### DIFF
--- a/_common/shippable/Adapter.js
+++ b/_common/shippable/Adapter.js
@@ -296,6 +296,14 @@ ShippableAdapter.prototype.getSteps =
     );
   };
 
+ShippableAdapter.prototype.getStepArtifactUrls =
+  function (stepId, query, callback) {
+    this.get(
+      util.format('/steps/%s/artifactUrl?%s', stepId, query),
+      callback
+    );
+  };
+
 // steplets
 // TODO: Make use of the actual API here, when it is available
 ShippableAdapter.prototype.getSteplets =

--- a/execute/executeStep.js
+++ b/execute/executeStep.js
@@ -20,6 +20,7 @@ var handOffAndPoll = require('./step/handOffAndPoll.js');
 var readStepStatus = require('./step/readStepStatus.js');
 var processOUTs = require('./step/processOUTs.js');
 var postReports = require('./step/postReports.js');
+var uploadArtifacts = require('./step/uploadArtifacts.js');
 var postVersion = require('./step/postVersion.js');
 
 function executeStep(externalBag, callback) {
@@ -56,6 +57,7 @@ function executeStep(externalBag, callback) {
       _readStepStatus.bind(null, bag),
       _processOUTs.bind(null, bag),
       _postReports.bind(null, bag),
+      _uploadArtifacts.bind(null, bag),
       _postVersion.bind(null, bag),
       _updateStepStatus.bind(null, bag),
       _closeCleanupGroup.bind(null, bag),
@@ -584,6 +586,28 @@ function _postReports(bag, next) {
     builderApiAdapter: bag.builderApiAdapter
   };
   postReports(innerBag,
+    function (err) {
+      if (err) {
+        bag.error = true;
+        bag.isCleanupGrpSuccess = false;
+      }
+      return next();
+    }
+  );
+}
+
+function _uploadArtifacts(bag, next) {
+  var who = bag.who + '|' + _uploadArtifacts.name;
+  logger.verbose(who, 'Inside');
+
+  var innerBag = {
+    stepData: bag.stepData,
+    stepConsoleAdapter: bag.stepConsoleAdapter,
+    stepWorkspacePath: bag.stepWorkspacePath,
+    builderApiAdapter: bag.builderApiAdapter
+  };
+
+  uploadArtifacts(innerBag,
     function (err) {
       if (err) {
         bag.error = true;

--- a/execute/step/postReports.js
+++ b/execute/step/postReports.js
@@ -130,7 +130,7 @@ function _readTestReport(bag, next) {
   } catch (err) {
     bag.stepConsoleAdapter.publishMsg(
       util.format('Could not parse file %s. Skipping.', jsonFilePath));
-    bag.stepConsoleAdapter.closeCmd(false);
+    bag.isGrpSuccess = false;
     return next();
   }
 
@@ -157,7 +157,6 @@ function _postTestReport(bag, next) {
           'stepId: %s', who, bag.step.id, err);
 
         bag.stepConsoleAdapter.publishMsg(msg);
-        bag.stepConsoleAdapter.closeCmd(false);
         bag.isGrpSuccess = false;
         return next(true);
       }

--- a/execute/step/scripts/Ubuntu_16.04/templates/parseReport.sh
+++ b/execute/step/scripts/Ubuntu_16.04/templates/parseReport.sh
@@ -1,27 +1,9 @@
 #!/bin/bash -e
-exec_cmd() {
-  cmd=$@
-  cmd_uuid=$(cat /proc/sys/kernel/random/uuid)
-  cmd_start_timestamp=`date +"%s"`
-  echo "__SH__CMD__START__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\"}|$cmd"
-  eval "$cmd"
-  cmd_status=$?
-  if [ "$2" ]; then
-    echo $2;
-  fi
-
-  cmd_end_timestamp=`date +"%s"`
-  # If cmd output has no newline at end, marker parsing
-  # would break. Hence force a newline before the marker.
-  echo ""
-  echo "__SH__CMD__END__|{\"type\":\"cmd\",\"sequenceNumber\":\"$cmd_start_timestamp\",\"id\":\"$cmd_uuid\",\"exitcode\":\"$cmd_status\"}|$cmd"
-  return $cmd_status
-}
 
 export STEP_WORKSPACE_DIR="%%stepWorkspaceDir%%"
 
 parse_test_reports() {
-  exec_cmd "echo 'Parsing test reports'"
+  echo 'Parsing test reports'
 
   local reports_dir=$STEP_WORKSPACE_DIR/upload/tests
 
@@ -30,11 +12,10 @@ parse_test_reports() {
     return 0
   fi
 
-  local parse_tests="/pipelines/reports/reports \
+  /pipelines/reports/reports \
     --destination $STEP_WORKSPACE_DIR \
     tests \
-    --source $reports_dir"
-  exec_cmd "$parse_tests"
+    --source $reports_dir
 }
 
-exec_cmd parse_test_reports
+parse_test_reports

--- a/execute/step/scripts/Ubuntu_16.04/templates/upload.sh
+++ b/execute/step/scripts/Ubuntu_16.04/templates/upload.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+export ARTIFACT_URL="%%artifactUrl%%"
+export ARTIFACT_NAME="%%artifactName%%"
+export STEP_WORKSPACE_DIR="%%stepWorkspaceDir%%"
+
+upload_report_files() {
+  local ARCHIVE_FILE="$STEP_WORKSPACE_DIR/$ARTIFACT_NAME"
+
+  tar -czf $ARCHIVE_FILE -C $STEP_WORKSPACE_DIR/upload .
+
+  echo 'Saving artifacts'
+  curl \
+    -s \
+    --connect-timeout 60 \
+    --max-time 120 \
+    -XPUT "$ARTIFACT_URL" \
+    -T "$ARCHIVE_FILE"
+}
+
+upload_report_files

--- a/execute/step/scripts/upload.js
+++ b/execute/step/scripts/upload.js
@@ -1,0 +1,138 @@
+'use strict';
+var self = upload;
+module.exports = self;
+
+var fs = require('fs');
+var executeScript = require('./executeScript.js');
+var exec = require('child_process').exec;
+var path = require('path');
+
+var _ = require('underscore');
+
+function upload(externalBag, callback) {
+
+  var bag = {
+    templatePath: path.resolve(__dirname,
+      'Ubuntu_16.04/templates/upload.sh'),
+    scriptPath: path.resolve(externalBag.stepWorkspacePath, 'upload.sh'),
+    artifactUrl: externalBag.artifactUrl,
+    artifactName: externalBag.artifactName,
+    stepWorkspacePath: externalBag.stepWorkspacePath,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    stepConsoleAdapter: externalBag.stepConsoleAdapter
+  };
+
+  bag.who = util.format('%s|step|handlers|%s', msName, self.name);
+  logger.verbose(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _generateScript.bind(null, bag),
+      _writeScript.bind(null, bag),
+      _executeTask.bind(null, bag)
+    ],
+    function (err) {
+      logger.verbose(bag.who, 'Completed');
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.debug(who, 'Inside');
+
+  var consoleErrors = [];
+
+  if (!bag.stepWorkspacePath)
+    consoleErrors.push(
+      util.format('%s is missing: stepWorkspacePath', who)
+    );
+
+  if (!bag.artifactUrl)
+    consoleErrors.push(
+      util.format('%s is missing: artifactUrl', who)
+    );
+
+  if (!bag.scriptPath)
+    consoleErrors.push(
+      util.format('%s is missing: scriptPath', who)
+    );
+
+  if (consoleErrors.length > 0) {
+    _.each(consoleErrors,
+      function (e) {
+        var msg = e;
+        logger.error(bag.who, e);
+        bag.stepConsoleAdapter.publishMsg(msg);
+      }
+    );
+    bag.stepConsoleAdapter.closeCmd(false);
+    return next(true);
+  }
+  bag.stepConsoleAdapter.publishMsg('All parameters present.');
+  return next();
+}
+
+function _generateScript(bag, next) {
+  var who = bag.who + '|' + _generateScript.name;
+  logger.debug(who, 'Inside');
+
+  var params = {
+    artifactUrl: bag.artifactUrl,
+    artifactName: bag.artifactName,
+    stepWorkspaceDir: bag.stepWorkspacePath
+  };
+
+  var scriptContent =
+    fs.readFileSync(bag.templatePath).toString();
+  var template = _.template(scriptContent);
+  bag.script = template(params);
+  bag.stepConsoleAdapter.publishMsg('Successfully generated script');
+
+  return next();
+}
+
+function _writeScript(bag, next) {
+  var who = bag.who + '|' + _writeScript.name;
+  logger.debug(who, 'Inside');
+
+  fs.writeFile(bag.scriptPath, bag.script,
+    function (err) {
+      var msg;
+      if (err) {
+        msg = util.format('%s, Failed to save script %s, %s',
+          who, bag.scriptPath, err);
+        bag.stepConsoleAdapter.publishMsg(msg);
+        bag.stepConsoleAdapter.closeCmd(false);
+        return next(err);
+      }
+
+      fs.chmodSync(bag.scriptPath, '755');
+      bag.stepConsoleAdapter.publishMsg('Successfully saved script');
+      return next();
+    }
+  );
+}
+
+function _executeTask(bag, next) {
+  var who = bag.who + '|' + _executeTask.name;
+  logger.debug(who, 'Inside');
+
+  var scriptBag = {
+    scriptPath: bag.scriptPath,
+    args: [],
+    options: {},
+    builderApiAdapter: bag.builderApiAdapter,
+    stepConsoleAdapter: bag.stepConsoleAdapter,
+    ignoreCmd: true
+  };
+
+  executeScript(scriptBag,
+    function (err) {
+      if (err)
+        logger.error(who, 'Failed to execute task', err);
+      return next(err);
+    }
+  );
+}

--- a/execute/step/uploadArtifacts.js
+++ b/execute/step/uploadArtifacts.js
@@ -1,0 +1,134 @@
+'use strict';
+
+var self = uploadArtifacts;
+module.exports = self;
+
+var path = require('path');
+var upload = require('./scripts/upload.js');
+
+function uploadArtifacts(externalBag, callback) {
+  var bag = {
+    artifactName: 'artifacts.tar.gz',
+    stepData: externalBag.stepData,
+    stepWorkspacePath: externalBag.stepWorkspacePath,
+    stepConsoleAdapter: externalBag.stepConsoleAdapter,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    isGrpSuccess: true
+  };
+
+  bag.stepConsoleAdapter.openCmd('Uploading archive for ' +
+    (bag.stepData && bag.stepData.step && bag.stepData.step.name));
+  bag.who = util.format('%s|step|%s', msName, self.name);
+  logger.info(bag.who, 'Inside');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _getArtifactUrl.bind(null, bag),
+      _uploadArtifacts.bind(null, bag)
+    ],
+    function (err) {
+      if (bag.isGrpSuccess)
+        bag.stepConsoleAdapter.closeCmd(true);
+      else
+        bag.stepConsoleAdapter.closeCmd(false);
+
+      if (err)
+        logger.error(bag.who, util.format('Failed to upload artifacts'));
+      else
+        logger.info(bag.who, 'Successfully uploaded artifacts');
+
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  var expectedParams = [
+    'stepData',
+    'stepConsoleAdapter',
+    'stepWorkspacePath',
+    'builderApiAdapter'
+  ];
+
+  var paramErrors = [];
+  _.each(expectedParams,
+    function (expectedParam) {
+      if (_.isNull(bag[expectedParam]) || _.isUndefined(bag[expectedParam]))
+        paramErrors.push(
+          util.format('%s: missing param :%s', who, expectedParam)
+        );
+    }
+  );
+
+  var hasErrors = !_.isEmpty(paramErrors);
+  if (hasErrors)
+    logger.error(paramErrors.join('\n'));
+
+  bag.step = {
+    id: bag.stepData.step.id,
+    name: bag.stepData.step.name
+  };
+
+  return next(hasErrors);
+}
+
+function _getArtifactUrl(bag, next) {
+  var who = bag.who + '|' + _getArtifactUrl.name;
+  logger.verbose(who, 'Inside');
+
+  bag.stepConsoleAdapter.publishMsg('Getting upload URL');
+
+  var query = 'artifactName=' + bag.artifactName;
+
+  bag.builderApiAdapter.getStepArtifactUrls(bag.step.id, query,
+    function (err, artifactUrls) {
+      var msg;
+      if (err) {
+        msg = util.format('%s, Failed to get artifact URLs for ' +
+          'stepId: %s', who, bag.step.id, err);
+
+        bag.stepConsoleAdapter.publishMsg(msg);
+        return next();
+      }
+
+      bag.artifactUrl = artifactUrls.put;
+      msg = util.format(
+        'Got artifact URL for stepId: %s ', bag.step.id);
+      bag.stepConsoleAdapter.publishMsg(msg);
+      return next();
+    }
+  );
+}
+
+function _uploadArtifacts(bag, next) {
+  if (!bag.artifactUrl) return next();
+  var who = bag.who + '|' + _uploadArtifacts.name;
+  logger.verbose(who, 'Inside');
+
+  bag.stepConsoleAdapter.publishMsg('Uploading reports');
+
+  var scriptBag = {
+    artifactUrl: bag.artifactUrl,
+    artifactName: bag.artifactName,
+    stepWorkspacePath: bag.stepWorkspacePath,
+    builderApiAdapter: bag.builderApiAdapter,
+    stepConsoleAdapter: bag.stepConsoleAdapter
+  };
+
+  upload(scriptBag,
+    function (err) {
+      if (err) {
+        bag.isGrpSuccess = false;
+        logger.error(who,
+          util.format('Failed to upload artifacts with error: %s', err)
+        );
+        return next(true);
+      }
+      logger.debug('Successfully uploaded artifacts');
+      return next();
+    }
+  );
+}


### PR DESCRIPTION
#90 

Uploads step artifacts, if a filestore option is configured.  And changes some of the report parsing logs.

With filestore:
<img width="1077" alt="Screen Shot 2019-04-25 at 10 28 35 AM" src="https://user-images.githubusercontent.com/5492015/56756695-34578280-6747-11e9-9dc0-834849b62ccf.png">

Without filestore:
<img width="1070" alt="Screen Shot 2019-04-25 at 10 29 34 AM" src="https://user-images.githubusercontent.com/5492015/56756696-34578280-6747-11e9-9608-ca7d1176b918.png">