### PR TITLE
#93; downloads latest artifacts when setting up step.

### DIFF
--- a/_common/shippable/Adapter.js
+++ b/_common/shippable/Adapter.js
@@ -304,6 +304,14 @@ ShippableAdapter.prototype.getStepArtifactUrls =
     );
   };
 
+ShippableAdapter.prototype.getLatestArtifactUrlForStepName =
+  function (projectId, stepName, callback) {
+    this.get(
+      util.format('/projects/%s/%s/latestArchive', projectId, stepName),
+      callback
+    );
+  };
+
 // steplets
 // TODO: Make use of the actual API here, when it is available
 ShippableAdapter.prototype.getSteplets =

--- a/execute/executeStep.js
+++ b/execute/executeStep.js
@@ -21,6 +21,7 @@ var readStepStatus = require('./step/readStepStatus.js');
 var processOUTs = require('./step/processOUTs.js');
 var postReports = require('./step/postReports.js');
 var uploadArtifacts = require('./step/uploadArtifacts.js');
+var downloadArtifacts = require('./step/downloadArtifacts.js');
 var postVersion = require('./step/postVersion.js');
 
 function executeStep(externalBag, callback) {
@@ -50,6 +51,7 @@ function executeStep(externalBag, callback) {
       _constructStepJson.bind(null, bag),
       _decryptSecureEnvs.bind(null, bag),
       _addStepJson.bind(null, bag),
+      _downloadArtifacts.bind(null, bag),
       _processINs.bind(null, bag),
       _createStepletScript.bind(null, bag),
       _closeSetupGroup.bind(null, bag),
@@ -412,6 +414,29 @@ function _addStepJson(bag, next) {
         bag.stepConsoleAdapter.publishMsg('Successfully saved step.json at: ' +
           bag.stepJsonPath);
         bag.stepConsoleAdapter.closeCmd(true);
+      }
+      return next();
+    }
+  );
+}
+
+function _downloadArtifacts(bag, next) {
+  var who = bag.who + '|' + _downloadArtifacts.name;
+  logger.verbose(who, 'Inside');
+
+  var innerBag = {
+    stepData: bag.stepData,
+    projectId: bag.projectId,
+    stepConsoleAdapter: bag.stepConsoleAdapter,
+    stepWorkspacePath: bag.stepWorkspacePath,
+    builderApiAdapter: bag.builderApiAdapter
+  };
+
+  downloadArtifacts(innerBag,
+    function (err) {
+      if (err) {
+        bag.error = true;
+        bag.isCleanupGrpSuccess = false;
       }
       return next();
     }

--- a/execute/step/downloadArtifacts.js
+++ b/execute/step/downloadArtifacts.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var self = downloadArtifacts;
+module.exports = self;
+
+var path = require('path');
+var download = require('./scripts/download.js');
+
+function downloadArtifacts(externalBag, callback) {
+  var bag = {
+    stepData: externalBag.stepData,
+    projectId: externalBag.projectId,
+    stepWorkspacePath: externalBag.stepWorkspacePath,
+    stepConsoleAdapter: externalBag.stepConsoleAdapter,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    isGrpSuccess: true
+  };
+
+  bag.stepConsoleAdapter.openCmd('Downloading archive for ' +
+    (bag.stepData && bag.stepData.step && bag.stepData.step.name));
+  bag.who = util.format('%s|step|%s', msName, self.name);
+  logger.info(bag.who, 'Inside');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _getArtifactUrl.bind(null, bag),
+      _downloadArtifacts.bind(null, bag)
+    ],
+    function (err) {
+      if (bag.isGrpSuccess)
+        bag.stepConsoleAdapter.closeCmd(true);
+      else
+        bag.stepConsoleAdapter.closeCmd(false);
+
+      if (err)
+        logger.error(bag.who, util.format('Failed to download artifacts'));
+      else
+        logger.info(bag.who, 'Successfully downloaded artifacts');
+
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  var expectedParams = [
+    'stepData',
+    'stepConsoleAdapter',
+    'stepWorkspacePath',
+    'builderApiAdapter'
+  ];
+
+  var paramErrors = [];
+  _.each(expectedParams,
+    function (expectedParam) {
+      if (_.isNull(bag[expectedParam]) || _.isUndefined(bag[expectedParam]))
+        paramErrors.push(
+          util.format('%s: missing param :%s', who, expectedParam)
+        );
+    }
+  );
+
+  var hasErrors = !_.isEmpty(paramErrors);
+  if (hasErrors)
+    logger.error(paramErrors.join('\n'));
+
+  bag.step = {
+    id: bag.stepData.step.id,
+    projectId: bag.projectId,
+    name: bag.stepData.step.name
+  };
+
+  bag.artifactName = 'archive.tar.gz';
+
+  return next(hasErrors);
+}
+
+function _getArtifactUrl(bag, next) {
+  var who = bag.who + '|' + _getArtifactUrl.name;
+  logger.verbose(who, 'Inside');
+
+  bag.stepConsoleAdapter.publishMsg('Getting download URL');
+
+  bag.builderApiAdapter.getLatestArtifactUrlForStepName(bag.step.projectId,
+    bag.step.name,
+    function (err, artifactUrls) {
+      var msg;
+      if (err) {
+        msg = util.format('%s, Failed to get artifact URL for ' +
+          'step %s', who, bag.step.name, err);
+
+        bag.stepConsoleAdapter.publishMsg(msg);
+        return next();
+      }
+
+      bag.artifactUrl = artifactUrls.get;
+      msg = util.format(
+        'Got artifact URL for stepId: %s ', bag.step.id);
+      bag.stepConsoleAdapter.publishMsg(msg);
+      return next();
+    }
+  );
+}
+
+function _downloadArtifacts(bag, next) {
+  if (!bag.artifactUrl) return next();
+  var who = bag.who + '|' + _downloadArtifacts.name;
+  logger.verbose(who, 'Inside');
+
+  bag.stepConsoleAdapter.publishMsg('Downloading artifacts');
+
+  var scriptBag = {
+    artifactUrl: bag.artifactUrl,
+    artifactName: bag.artifactName,
+    stepWorkspacePath: bag.stepWorkspacePath,
+    builderApiAdapter: bag.builderApiAdapter,
+    stepConsoleAdapter: bag.stepConsoleAdapter
+  };
+
+  download(scriptBag,
+    function (err) {
+      if (err) {
+        bag.isGrpSuccess = false;
+        logger.error(who,
+          util.format('Failed to download artifacts with error: %s', err)
+        );
+        return next(true);
+      }
+      logger.debug('Successfully downloaded artifacts');
+      return next();
+    }
+  );
+}

--- a/execute/step/scripts/Ubuntu_16.04/templates/download.sh
+++ b/execute/step/scripts/Ubuntu_16.04/templates/download.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+export ARTIFACT_URL="%%artifactUrl%%"
+export ARTIFACT_NAME="%%artifactName%%"
+export STEP_WORKSPACE_DIR="%%stepWorkspaceDir%%"
+
+download_artifacts() {
+  local ARCHIVE_FILE="$STEP_WORKSPACE_DIR/$ARTIFACT_NAME"
+
+  echo 'Downloading artifacts'
+  curl \
+    -s \
+    --connect-timeout 60 \
+    --max-time 120 \
+    -XGET "$ARTIFACT_URL" \
+    -o "$ARCHIVE_FILE"
+
+  tar -xzf $ARCHIVE_FILE -C $STEP_WORKSPACE_DIR/download
+  rm $ARCHIVE_FILE
+}
+
+download_artifacts

--- a/execute/step/scripts/download.js
+++ b/execute/step/scripts/download.js
@@ -1,0 +1,138 @@
+'use strict';
+var self = download;
+module.exports = self;
+
+var fs = require('fs');
+var executeScript = require('./executeScript.js');
+var exec = require('child_process').exec;
+var path = require('path');
+
+var _ = require('underscore');
+
+function download(externalBag, callback) {
+
+  var bag = {
+    templatePath: path.resolve(__dirname,
+      'Ubuntu_16.04/templates/download.sh'),
+    scriptPath: path.resolve(externalBag.stepWorkspacePath, 'download.sh'),
+    artifactUrl: externalBag.artifactUrl,
+    artifactName: externalBag.artifactName,
+    stepWorkspacePath: externalBag.stepWorkspacePath,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    stepConsoleAdapter: externalBag.stepConsoleAdapter
+  };
+
+  bag.who = util.format('%s|step|handlers|%s', msName, self.name);
+  logger.verbose(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _generateScript.bind(null, bag),
+      _writeScript.bind(null, bag),
+      _executeTask.bind(null, bag)
+    ],
+    function (err) {
+      logger.verbose(bag.who, 'Completed');
+      return callback(err);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.debug(who, 'Inside');
+
+  var consoleErrors = [];
+
+  if (!bag.stepWorkspacePath)
+    consoleErrors.push(
+      util.format('%s is missing: stepWorkspacePath', who)
+    );
+
+  if (!bag.artifactUrl)
+    consoleErrors.push(
+      util.format('%s is missing: artifactUrl', who)
+    );
+
+  if (!bag.scriptPath)
+    consoleErrors.push(
+      util.format('%s is missing: scriptPath', who)
+    );
+
+  if (consoleErrors.length > 0) {
+    _.each(consoleErrors,
+      function (e) {
+        var msg = e;
+        logger.error(bag.who, e);
+        bag.stepConsoleAdapter.publishMsg(msg);
+      }
+    );
+    bag.stepConsoleAdapter.closeCmd(false);
+    return next(true);
+  }
+  bag.stepConsoleAdapter.publishMsg('All parameters present.');
+  return next();
+}
+
+function _generateScript(bag, next) {
+  var who = bag.who + '|' + _generateScript.name;
+  logger.debug(who, 'Inside');
+
+  var params = {
+    artifactUrl: bag.artifactUrl,
+    artifactName: bag.artifactName,
+    stepWorkspaceDir: bag.stepWorkspacePath
+  };
+
+  var scriptContent =
+    fs.readFileSync(bag.templatePath).toString();
+  var template = _.template(scriptContent);
+  bag.script = template(params);
+  bag.stepConsoleAdapter.publishMsg('Successfully generated script');
+
+  return next();
+}
+
+function _writeScript(bag, next) {
+  var who = bag.who + '|' + _writeScript.name;
+  logger.debug(who, 'Inside');
+
+  fs.writeFile(bag.scriptPath, bag.script,
+    function (err) {
+      var msg;
+      if (err) {
+        msg = util.format('%s, Failed to save script %s, %s',
+          who, bag.scriptPath, err);
+        bag.stepConsoleAdapter.publishMsg(msg);
+        bag.stepConsoleAdapter.closeCmd(false);
+        return next(err);
+      }
+
+      fs.chmodSync(bag.scriptPath, '755');
+      bag.stepConsoleAdapter.publishMsg('Successfully saved script');
+      return next();
+    }
+  );
+}
+
+function _executeTask(bag, next) {
+  var who = bag.who + '|' + _executeTask.name;
+  logger.debug(who, 'Inside');
+
+  var scriptBag = {
+    scriptPath: bag.scriptPath,
+    args: [],
+    options: {},
+    builderApiAdapter: bag.builderApiAdapter,
+    stepConsoleAdapter: bag.stepConsoleAdapter,
+    ignoreCmd: true
+  };
+
+  executeScript(scriptBag,
+    function (err) {
+      if (err)
+        logger.error(who, 'Failed to execute task', err);
+      return next(err);
+    }
+  );
+}


### PR DESCRIPTION
#93 

Logs with artifacts available:
<img width="1002" alt="Screen Shot 2019-04-25 at 4 05 17 PM" src="https://user-images.githubusercontent.com/5492015/56773796-a85c4f80-6774-11e9-9cab-a99547869671.png">

Logs without filestore:
<img width="1025" alt="Screen Shot 2019-04-25 at 4 05 40 PM" src="https://user-images.githubusercontent.com/5492015/56773797-a8f4e600-6774-11e9-82bd-6a368f7a2395.png">
