### PR TITLE
#96; skips cache download on reset.

### DIFF
--- a/execute/executeStep.js
+++ b/execute/executeStep.js
@@ -421,6 +421,12 @@ function _addStepJson(bag, next) {
 }
 
 function _downloadArtifacts(bag, next) {
+  if (bag.step.configPropertyBag && bag.step.configPropertyBag.reset) {
+    bag.stepConsoleAdapter.openCmd('Skipping artifact and cache download');
+    bag.stepConsoleAdapter.publishMsg('Step triggered with reset.');
+    bag.stepConsoleAdapter.closeCmd(true);
+    return next();
+  }
   var who = bag.who + '|' + _downloadArtifacts.name;
   logger.verbose(who, 'Inside');
 

--- a/execute/step/downloadArtifacts.js
+++ b/execute/step/downloadArtifacts.js
@@ -3,7 +3,6 @@
 var self = downloadArtifacts;
 module.exports = self;
 
-var path = require('path');
 var download = require('./scripts/download.js');
 
 function downloadArtifacts(externalBag, callback) {

--- a/execute/step/scripts/download.js
+++ b/execute/step/scripts/download.js
@@ -4,7 +4,6 @@ module.exports = self;
 
 var fs = require('fs');
 var executeScript = require('./executeScript.js');
-var exec = require('child_process').exec;
 var path = require('path');
 
 var _ = require('underscore');

--- a/execute/step/scripts/parseTestReports.js
+++ b/execute/step/scripts/parseTestReports.js
@@ -4,7 +4,6 @@ module.exports = self;
 
 var fs = require('fs');
 var executeScript = require('./executeScript.js');
-var exec = require('child_process').exec;
 var path = require('path');
 
 var _ = require('underscore');

--- a/execute/step/scripts/upload.js
+++ b/execute/step/scripts/upload.js
@@ -4,7 +4,6 @@ module.exports = self;
 
 var fs = require('fs');
 var executeScript = require('./executeScript.js');
-var exec = require('child_process').exec;
 var path = require('path');
 
 var _ = require('underscore');

--- a/execute/step/uploadArtifacts.js
+++ b/execute/step/uploadArtifacts.js
@@ -3,7 +3,6 @@
 var self = uploadArtifacts;
 module.exports = self;
 
-var path = require('path');
 var upload = require('./scripts/upload.js');
 
 function uploadArtifacts(externalBag, callback) {


### PR DESCRIPTION
#96 

Skips cache/artifact download when `reset` is `true` in the step `configPropertyBag`.  And removes a few unused `require`s.

<img width="595" alt="Screen Shot 2019-04-26 at 4 21 48 PM" src="https://user-images.githubusercontent.com/5492015/56841144-c099a080-6840-11e9-8a1a-6d9db56aed27.png">
