### PR TITLE
single quote escape only when required

### DIFF
--- a/assembler/assemble.js
+++ b/assembler/assemble.js
@@ -16,6 +16,8 @@ var isFile = require('../_common/helpers/isFile.js');
 
 var assemblyOrder = ['onSuccess', 'onFailure', 'onComplete',
   'environmentVariables', 'image', 'auto', 'input', 'onStart', 'onExecute'];
+var singleQuoteEscapeSections = ['onSuccess', 'onFailure', 'onComplete',
+  'onStart', 'onExecute'];
 
 function assemble(externalBag, callback) {
   var bag = {
@@ -154,12 +156,16 @@ function __addTemplate(parentDirectoryName, currentDirectoryPath, context,
             contentName), 'utf8').toString();
           var template = _.template(templateScript);
           if (_.isString(context)) {
-            script = template({ 'context': __escapeString(context) });
+            script = template({ 'context': context });
           } else if (_.isArray(context)) {
             _.each(context,
               function (element) {
                 if (_.isString(element)) {
-                  script += template({ 'context': __escapeString(element) });
+                  if (_.contains(singleQuoteEscapeSections,
+                    parentDirectoryName) ||
+                    _.contains(singleQuoteEscapeSections, contentName))
+                    element = __escapeString(element);
+                  script += template({ 'context': element });
                 } else if (_.isObject(element)) {
                   script += template({ 'context': element });
                 }

--- a/execute/step/prepData.js
+++ b/execute/step/prepData.js
@@ -207,8 +207,6 @@ function _getResources(bag, next) {
               runResourceVersion.resourceId = resource.id;
               runResourceVersion.systemPropertyBag = resource.systemPropertyBag;
               runResourceVersion.staticPropertyBag = resource.staticPropertyBag;
-              runResourceVersion.configPropertyBag =
-                resource.ymlConfigPropertyBag;
             }
           }
         );


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqProc/issues/98

the single quote escaping is done only for support `eval $'{cmd}'` This type of template is present only in bash's onComplete, onSuccess, onFailure, onStart, onExecute. Escaping the same way across all string might cause problems. We cannot have `'` in templates which will be escaped. So, I have added the escaping only for those templates which get user defined arrays of strings.