### PR TITLE
#128; allows resources as both inputs and outputs.

### DIFF
--- a/execute/step/createDependencyScripts.js
+++ b/execute/step/createDependencyScripts.js
@@ -80,38 +80,43 @@ function _assembleDependencyScripts(bag, next) {
       var resourceType =
         global.systemCodesByCode[resource.resourceTypeCode].name;
       var templateScript;
-      var operationType = resource.operation === 'IN'? 'dependsOn' : 'output';
-      var dependencyTemplatePath = path.join(bag.execTemplatesRootDir,
-        'resources', resourceType, operationType + '.sh');
-      try {
-        templateScript = fs.readFileSync(dependencyTemplatePath,
-          'utf8').toString();
-      } catch(e) {
-        logger.debug(util.inspect(e));
-      }
-      if (_.isEmpty(templateScript)) return;
-      var err = false;
-      var template = _.template(templateScript);
-      try {
-        if (resource.operation === 'IN')
-          bag.inDependencyScripts.push(template({ 'context': resource }));
-        else
-          bag.outDependencyScripts.push(template({ 'context': resource }));
-      } catch(e) {
-        err = true;
-        error = true;
-        logger.error(util.inspect(e));
-      }
-      if (err)
-        bag.stepConsoleAdapter.publishMsg(
-          util.format('Failed to create dependency script for resource: %s',
-          resource.resourceName)
-        );
-      else
-        bag.stepConsoleAdapter.publishMsg(
-          util.format('Successfully created dependency script for ' +
-          'resource: %s', resource.resourceName)
-        );
+      _.each(resource.operations,
+        function (operation) {
+          var operationType = operation === 'IN' ? 'dependsOn' : 'output';
+          var dependencyTemplatePath = path.join(bag.execTemplatesRootDir,
+            'resources', resourceType, operationType + '.sh');
+          try {
+            templateScript = fs.readFileSync(dependencyTemplatePath,
+              'utf8').toString();
+          } catch(e) {
+            logger.debug(util.inspect(e));
+          }
+          if (_.isEmpty(templateScript)) return;
+          var err = false;
+          var template = _.template(templateScript);
+          try {
+            if (operation === 'IN')
+              bag.inDependencyScripts.push(template({ 'context': resource }));
+            else
+              bag.outDependencyScripts.push(template({ 'context': resource }));
+          } catch(e) {
+            err = true;
+            error = true;
+            logger.error(util.inspect(e));
+          }
+          if (err)
+            bag.stepConsoleAdapter.publishMsg(
+              util.format('Failed to create dependency script for resource: %s',
+              resource.resourceName)
+            );
+          else
+            bag.stepConsoleAdapter.publishMsg(
+              util.format('Successfully created dependency script for ' +
+              'resource: %s', resource.resourceName)
+            );
+
+        }
+      )
     }
   );
 

--- a/execute/step/postVersion.js
+++ b/execute/step/postVersion.js
@@ -65,7 +65,7 @@ function _postOutResourceVersions(bag, next) {
   async.eachSeries(bag.stepData.resources,
     function (resource, nextResource) {
       var outDependency = {};
-      if (resource.operation === 'OUT') {
+      if (_.contains(resource.operations, 'OUT')) {
         outDependency.name = resource.resourceName;
         outDependency.id = resource.resourceId;
         outDependency.resourceVersionContentPropertyBag =


### PR DESCRIPTION
#128 

Replaces `operation` in the `step.json` with `operations` so that resources can be both inputs and outputs.