### PR TITLE
#130; include createdByStepId in new resourceVersions.

### DIFF
--- a/execute/step/postVersion.js
+++ b/execute/step/postVersion.js
@@ -83,6 +83,7 @@ function _postOutResourceVersions(bag, next) {
         stepOutDir: bag.stepOutDir,
         builderApiAdapter: bag.builderApiAdapter,
         dependency: outDependency,
+        stepId: bag.stepData.step.id,
         versionJson: {},
         hasEnv: true,
         isChanged: false,
@@ -221,6 +222,7 @@ function __postResourceVersion(bag, next) {
   var newResourceVersion = {
     resourceId: bag.dependency.id,
     contentPropertyBag: bag.versionJson,
+    createdByStepId: bag.stepId,
     projectId: bag.dependency.projectId
   };
 


### PR DESCRIPTION
#130 

Includes `createdByStepId` in resourceVersions created. The updated resources will no longer trigger the pipeline again.