### PR TITLE
fix rrv get and delay processing status

### DIFF
--- a/execute/step/createDependencyScripts.js
+++ b/execute/step/createDependencyScripts.js
@@ -123,7 +123,7 @@ function _assembleDependencyScripts(bag, next) {
     bag.stepConsoleAdapter.closeCmd(false);
     return next(true);
   }
-
+  bag.stepConsoleAdapter.closeCmd(true);
   return next();
 }
 

--- a/execute/step/prepData.js
+++ b/execute/step/prepData.js
@@ -89,18 +89,7 @@ function _getRunResourceVersions(bag, next) {
         bag.stepConsoleAdapter.closeCmd(false);
         return next(err);
       } else {
-        var rrvMap = {};
-        _.each(runResVersions,
-          function (rrv) {
-            if (_.isEmpty(rrvMap[rrv.resourceName]))
-              rrvMap[rrv.resourceName] = rrv;
-            else {
-              if (rrv.createdAt > rrvMap[rrv.resourceName].createdAt)
-                rrvMap[rrv.resourceName] = rrv;
-            }
-          }
-        );
-        bag.runResourceVersions = _.values(rrvMap);
+        bag.runResourceVersions = runResVersions;
         bag.stepConsoleAdapter.publishMsg(
           'Successfully fetched run resource versions with stepId: ' +
           bag.stepId);

--- a/microWorker.js
+++ b/microWorker.js
@@ -162,7 +162,7 @@ function _getNextStep(bag, next) {
     function (err, result) {
       if (err) {
         logger.warn(util.format('%s, failed to get next step ' +
-        'for group: %s with error: %s', bag.who, bag.affinityGroup, err));
+          'for group: %s with error: %s', bag.who, bag.affinityGroup, err));
         bag.groupComplete = true;
       } else
         bag.stepId = result.stepIds[0];
@@ -185,7 +185,7 @@ function _getSteplets(bag, next) {
     function (err, steplets) {
       if (err)
         logger.warn(util.format('%s, failed to get steplets for ' +
-        'stepId: %s with error: %s', bag.who, bag.stepId, err));
+          'stepId: %s with error: %s', bag.who, bag.stepId, err));
       bag.steplets = steplets;
       return next();
     }


### PR DESCRIPTION
closes #186

In additino to the RRV this makes a couple other changes for things that i noticed. seemed convenient to do it while touchign reqproc.

1. `Assembling scripts for required resources` when successful never closes the command. it does a close false when it fails, but never a close true. this was noticeable int he UI:
![image](https://user-images.githubusercontent.com/6869398/57961675-659a1d00-78c5-11e9-8d33-a1bce16709ec.png)


2. when speaking with Avi about affinity groups and statuses, we eventually concluded that steptrigger should put a group into 'inProgress', reqproc should put an individual step into 'queued', and reqkick/reqexec should put the individual step into processing.  This is not moving it all the way to reqKick, that part i still need to confirm, but this will move it farther along the chain so that the seapration of queued and processing is potentially more clear.  At the moment reqKick doesnt know what a step is, only a steplet. this is the better solution for now.

3. indentation in microworker that i noticed.