### PR TITLE
marks powershell to be default shell for Windows Server 2019

### DIFF
--- a/_common/micro/setupMS.js
+++ b/_common/micro/setupMS.js
@@ -39,7 +39,7 @@ function setupMS(params) {
     process.env.SHIPPABLE_NODE_OPERATING_SYSTEM;
   global.config.execTemplatesRootDir = process.env.IMAGE_EXEC_TEMPLATES_DIR;
 
-  if (global.config.shippableNodeOperatingSystem === 'WindowsServer_2016') {
+  if (global.config.shippableNodeOperatingSystem === 'WindowsServer_2019') {
     global.config.scriptExtension = 'ps1';
     global.config.defaultShell = 'powershell';
     global.config.defaultShellArgs = [];


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqProc/issues/193

PowerShell is supported only for Windows Server 2019 in the current system. So setting it to be default shell only for it.