### PR TITLE
Modified reqProc to be compatible for powershell step

### DIFF
--- a/assembler/assemble.js
+++ b/assembler/assemble.js
@@ -18,6 +18,7 @@ var assemblyOrder = ['onSuccess', 'onFailure', 'onComplete', 'output',
   'environmentVariables', 'image', 'auto', 'dependsOn', 'onStart', 'onExecute'];
 var singleQuoteEscapeSections = ['onSuccess', 'onFailure', 'onComplete',
   'onStart', 'onExecute'];
+var nonNativeStepTypes = ['bash', 'powershell'];
 
 function assemble(externalBag, callback) {
   var bag = {
@@ -82,7 +83,9 @@ function _checkInputParams(bag, next) {
 }
 
 function _assembleNativeScriptFragment(bag, next) {
-  if (bag.objectType !== 'steps' || bag.objectSubType === 'bash') return next();
+  if (bag.objectType !== 'steps' ||
+    _.contains(nonNativeStepTypes, bag.objectSubType))
+    return next();
 
   var who = bag.who + '|' + _assembleNativeScriptFragment.name;
   logger.verbose(who, 'Inside');
@@ -106,7 +109,9 @@ function _assembleNativeScriptFragment(bag, next) {
 }
 
 function _combineNativeScriptFragment(bag, next) {
-  if (bag.objectType !== 'steps' || bag.objectSubType === 'bash') return next();
+  if (bag.objectType !== 'steps' ||
+    _.contains(nonNativeStepTypes, bag.objectSubType))
+    return next();
 
   var who = bag.who + '|' + _combineNativeScriptFragment.name;
   logger.verbose(who, 'Inside');

--- a/assembler/assemble.js
+++ b/assembler/assemble.js
@@ -177,10 +177,10 @@ function __addTemplate(parentDirectoryName, currentDirectoryPath, context,
   directoryContents.sort(
     function (a, b) {
       if (a === b) return 0;
-      if (a === 'header.sh') return -1;
-      if (b === 'header.sh') return 1;
-      if (a === 'footer.sh') return 1;
-      if (b === 'footer.sh') return -1;
+      if (a === 'header.' + global.config.scriptExtension) return -1;
+      if (b === 'header.' + global.config.scriptExtension) return 1;
+      if (a === 'footer.' + global.config.scriptExtension) return 1;
+      if (b === 'footer.' + global.config.scriptExtension) return -1;
       if (a < b) return -1;
       return 1;
     }
@@ -208,8 +208,9 @@ function __addTemplate(parentDirectoryName, currentDirectoryPath, context,
         if (_.isEmpty(bag.assembledScript[parentDirectoryName].footer))
           bag.assembledScript[parentDirectoryName].footer = '';
 
-        if (contentName === parentDirectoryName + '.sh' ||
-          contentName === context + '.sh') {
+        if (contentName === parentDirectoryName + '.' +
+          global.config.scriptExtension ||
+          contentName === context + '.' + global.config.scriptExtension) {
           var templateScript = fs.readFileSync(path.join(currentDirectoryPath,
             contentName), 'utf8').toString();
           var template = _.template(templateScript);
@@ -238,11 +239,11 @@ function __addTemplate(parentDirectoryName, currentDirectoryPath, context,
           }
 
           bag.assembledScript[parentDirectoryName].script += script;
-        } else if (contentName === 'header.sh') {
+        } else if (contentName === 'header.' + global.config.scriptExtension) {
           bag.assembledScript[parentDirectoryName].header =
             fs.readFileSync(path.join(currentDirectoryPath, contentName),
               'utf8').toString();
-        } else if (contentName === 'footer.sh') {
+        } else if (contentName === 'footer.' + global.config.scriptExtension) {
           bag.assembledScript[parentDirectoryName].footer =
             fs.readFileSync(path.join(currentDirectoryPath, contentName),
               'utf8').toString();

--- a/assembler/assemble.js
+++ b/assembler/assemble.js
@@ -161,7 +161,10 @@ function _combineScript(bag, next) {
   var who = bag.who + '|' + _combineScript.name;
   logger.verbose(who, 'Inside');
 
-  _.each([ bag.objectSubType ].concat(assemblyOrder),
+  if (bag.assembledScript[bag.objectSubType].header)
+    bag.script += bag.assembledScript[bag.objectSubType].header;
+
+  _.each(assemblyOrder,
     function (component) {
       if (!_.isEmpty(bag.assembledScript[component]))
         bag.script += (bag.assembledScript[component].header +
@@ -169,6 +172,10 @@ function _combineScript(bag, next) {
           bag.assembledScript[component].footer);
     }
   );
+
+  if (bag.assembledScript[bag.objectSubType].footer)
+    bag.script += bag.assembledScript[bag.objectSubType].footer;
+
   return next();
 }
 

--- a/execute/step/createStepletScript.js
+++ b/execute/step/createStepletScript.js
@@ -217,7 +217,7 @@ function _setJobEnvs(bag, next) {
   jobEnvs.push(util.format('STEP_DOCKER_CONTAINER_NAME=%s',
     bag.stepDockerContainerName));
 
-  if (global.config.shippableNodeOperatingSystem === 'WindowsServer_2016')
+  if (global.config.shippableNodeOperatingSystem === 'WindowsServer_2019')
     jobEnvs.push('REQEXEC_SHELL=powershell.exe');
 
   var envPath = path.join(bag.statusDir, 'step.env');

--- a/execute/step/createStepletScript.js
+++ b/execute/step/createStepletScript.js
@@ -41,9 +41,11 @@ function createStepletScript(externalBag, callback) {
     ],
     function (err) {
       if (err)
-        logger.error(bag.who, util.format('Failed to create stepletScript.sh'));
+        logger.error(bag.who, util.format('Failed to create stepletScript.' +
+          global.config.scriptExtension));
       else
-        logger.info(bag.who, 'Successfully created stepletScript.sh');
+        logger.info(bag.who, 'Successfully created stepletScript.' +
+          global.config.scriptExtension);
 
       return callback(err);
     }

--- a/execute/step/setupDirectories.js
+++ b/execute/step/setupDirectories.js
@@ -142,7 +142,8 @@ function _setupDirectories(bag, next) {
         path.join(bag.stepDir, steplet.id.toString(), 'steplet.json'));
 
       var stepletScriptPath = path.join(bag.stepDir,
-        steplet.id.toString(), 'stepletScript.sh');
+        steplet.id.toString(), 'stepletScript.' +
+          global.config.scriptExtension);
       bag.filesToBeCreated.push(stepletScriptPath);
       bag.stepletScriptPaths.push(stepletScriptPath);
     }


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqProc/issues/193

## Success
```yml
      - name: test_basic_full_execute
        type: powershell
        execution:
          onStart:
            - Write-Output "starting onStart"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onExecute:
            - Write-Output "starting onExecute"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onSuccess:
            - Write-Output "starting onSuccess"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onComplete:
            - Write-Output "starting onComplete"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
```
![image](https://user-images.githubusercontent.com/4211715/58182204-d2992280-7cca-11e9-9bf7-1c3910db4b6b.png)

## Failure
```yml
      - name: test_basic_execute_failure
        type: powershell
        execution:
          onStart:
            - Write-Output "starting onStart"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onExecute:
            - Write-Output "starting onExecute"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
            - cat invalid-file.txt
            - Write-Output "this should not be executed"
          onSuccess:
            - Write-Output "starting onSuccess"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onFailure:
            - Write-Output "starting onFailure"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onComplete:
            - Write-Output "starting onComplete"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
```
![image](https://user-images.githubusercontent.com/4211715/58182401-29066100-7ccb-11e9-918a-0f66427e2764.png)
