### PR TITLE
#203; skips pipeline state upload when files are unchanged.

### DIFF
--- a/execute/step/scripts/Ubuntu_16.04/templates/download.sh
+++ b/execute/step/scripts/Ubuntu_16.04/templates/download.sh
@@ -177,6 +177,18 @@ download_pipeline_state() {
     tar -xzf $archive_file -C $PIPELINE_WORKSPACE_DIR
     rm $archive_file
     echo 'Downloaded pipeline state'
+
+    if [ -z "$(ls -A $PIPELINE_WORKSPACE_DIR)" ]; then
+      echo "Pipeline state is empty."
+    else
+      for file in $PIPELINE_WORKSPACE_DIR/*; do
+        md5sum $file
+      done > $STEP_WORKSPACE_DIR/checksums.txt
+
+      cat $STEP_WORKSPACE_DIR/checksums.txt | sort > $STEP_WORKSPACE_DIR/pipelineStateChecksums.txt
+      rm $STEP_WORKSPACE_DIR/checksums.txt
+    fi
+
   else
     echo 'No previous pipeline state'
   fi


### PR DESCRIPTION
#203 

Tested with empty state, unchanged state, and changed state.  No state will be uploaded if there is nothing in the pipeline workspace at the beginning and nothing at the end.  This does mean that some pipelines may never have any state saved, if they never have anything to save.