### PR TITLE
#220; handles converting generic integration objects to environment v…

### DIFF
--- a/execute/step/constructStepJson.js
+++ b/execute/step/constructStepJson.js
@@ -256,8 +256,12 @@ function __createIntegrationObject(integration) {
     name: integration.name,
     masterName: integration.masterIntegrationName
   };
-  integrationObject.formJSONValues =
-    getValuesFromIntegrationJson(integration.formJSONValues);
+
+  var formJSONValues = getValuesFromIntegrationJson(integration.formJSONValues);
+  if (integration.masterIntegrationName === 'generic')
+    integrationObject.formJSONValues = formJSONValues.envs || {};
+  else
+    integrationObject.formJSONValues = formJSONValues;
 
   return integrationObject;
 }


### PR DESCRIPTION
…ariables.

#220 

If the integration is a `generic` integration, treats the `envs` as the `formJSONValues`.  This might override the `name`, `id`, or `masterName`, if one of those happens to be a key, but given the intended purpose of this integration that seems reasonable.  It would be overridden in both the environment variables and the step JSON.