### PR TITLE
makes restricted envs to be read-only

### DIFF
--- a/execute/step/constructStepJson.js
+++ b/execute/step/constructStepJson.js
@@ -95,33 +95,40 @@ function _prepareStepJSON(bag, next) {
 
   bag.stepEnvs.push({
     key: 'STEP_ID',
-    value: bag.step.id
+    value: bag.step.id,
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'STEP_NAME',
-    value: bag.step.name
+    value: bag.step.name,
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'STEP_TYPE',
-    value: global.systemCodesByCode[bag.step.typeCode].name
+    value: global.systemCodesByCode[bag.step.typeCode].name,
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'STEP_URL',
     value: util.format('%s/%s/pipelines/%s/runs/%s/%s',
       global.config.wwwUrl, bag.project.name, bag.pipeline.name,
-      bag.step.runId, bag.step.id)
+      bag.step.runId, bag.step.id),
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'PIPELINE_NAME',
-    value: bag.pipeline.name
+    value: bag.pipeline.name,
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'RUN_ID',
-    value: bag.run.id
+    value: bag.run.id,
+    isReadOnly: true
   });
   bag.stepEnvs.push({
     key: 'RUN_NUMBER',
-    value: bag.run.runNumber
+    value: bag.run.runNumber,
+    isReadOnly: true
   });
 
   if (!_.isEmpty(bag.step.staticPropertyBag)) {

--- a/execute/step/createStepletScript.js
+++ b/execute/step/createStepletScript.js
@@ -120,7 +120,8 @@ function _setScriptEnvs(bag, next) {
     }, function (value, key) {
       bag.stepEnvs.push({
         'key': key,
-        'value': value
+        'value': value,
+        'isReadOnly': true
       });
     }
   );


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqProc/issues/224

#### Used in setup section of YML
```yml
- name: restricted_envs_in_setup_env_yml
  type: bash
  triggeredBy:
    steps:
      - start_u16_env
  setup:
    environmentVariables:
      normal:
        STEP_TYPE: update
        STEP_NAME: update
        PIPELINE_NAME: update
  execution:
    onExecute:
      - printenv
```
![image](https://user-images.githubusercontent.com/4211715/58627826-c712b080-82f5-11e9-9974-fb9c0dcd5acd.png)

#### Used from UI
![image](https://user-images.githubusercontent.com/4211715/58627897-ee697d80-82f5-11e9-8e0d-6f354e0c4bd6.png)
![image](https://user-images.githubusercontent.com/4211715/58627919-00e3b700-82f6-11e9-95a5-1f20f7a705cb.png)

#### Used in step execution section of the YML
```yml
- name: restricted_envs_in_step_exection
  type: bash
  triggeredBy:
    steps:
      - start_u16_env
  execution:
    onExecute:
      - printenv
      - echo "$STEP_ID"
      - STEP_ID=50
      - echo "step above this should fail"
```
![image](https://user-images.githubusercontent.com/4211715/58627975-1eb11c00-82f6-11e9-8672-32226f0d9242.png)


