### PR TITLE
save clusterNodeName in configPropertyBag

### DIFF
--- a/execute/executeStep.js
+++ b/execute/executeStep.js
@@ -448,10 +448,13 @@ function _updateStepToProcessing(bag, next) {
   timeoutAt.setSeconds(timeoutAt.getSeconds() +
     bag.step.configPropertyBag.timeoutSeconds);
 
+  var configPropertyBag = {};
+  configPropertyBag.clusterNodeName = bag.clusterNodeName;
   var update = {
     statusCode: statusCode,
     startedAt: new Date(),
-    timeoutAt: timeoutAt
+    timeoutAt: timeoutAt,
+    configPropertyBag: configPropertyBag
   };
   bag.builderApiAdapter.putStepById(bag.step.id, update,
     function (err) {


### PR DESCRIPTION
https://github.com/Shippable/kermit-reqProc/issues/271

updating step to save `clusterNodeName` in configPropertyBag while we are setting the status code to processing

<img width="1210" alt="Screenshot 2019-06-20 at 2 00 10 PM" src="https://user-images.githubusercontent.com/18304961/59833615-12076d00-9364-11e9-9c47-06964caa7fe6.png">
